### PR TITLE
Add lqs-savonet container build sources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /containers/lqs-savonet
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,61 @@
+name: Build and Publish Stream Image
+
+on:
+  pull_request:
+  push:
+    branches: [stable, next]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-image:
+    name: Build lqs-savonet image
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'noagenda'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set image tag
+        id: image-tag
+        shell: bash
+        run: |
+          BRANCH=${GITHUB_REF#refs/heads/}
+          # Docker tags cannot contain slashes; keep branch names readable
+          # while making them safe for GHCR tags.
+          BRANCH=${BRANCH//\//-}
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: containers/lqs-savonet
+          file: containers/lqs-savonet/Containerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ghcr.io/noagenda/noagendastream:${{ steps.image-tag.outputs.branch }}
+            ghcr.io/noagenda/noagendastream:${{ steps.image-tag.outputs.branch }}-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+      -
+        name: Print image digest
+        if: github.event_name == 'push'
+        run: |
+          echo "Published digest: ${{ steps.build.outputs.digest }}"
+          echo "Full reference: ghcr.io/noagenda/noagendastream@${{ steps.build.outputs.digest }}"

--- a/containers/lqs-savonet/Containerfile
+++ b/containers/lqs-savonet/Containerfile
@@ -1,0 +1,21 @@
+# 2.3.0-rc2
+#FROM savonet/liquidsoap:faffb13
+
+FROM docker.io/savonet/liquidsoap:v2.3.2
+#FROM docker.io/savonet/liquidsoap:rolling-release-v2.4.x
+
+MAINTAINER Mark van Dijk <operator+dockerfile@noagendastream.com>
+
+ENTRYPOINT []
+
+# Sync with rbemrose uid/gid
+# only on v2.3.0-rc2 and newer
+USER root
+#
+RUN set -ex; \
+    usermod -u 1002 -g 100 liquidsoap && \
+    chown -R 1002:100 /var/cache/liquidsoap
+
+USER liquidsoap
+
+CMD ["/usr/bin/liquidsoap", "/etc/liquidsoap/noagenda.liq"]

--- a/containers/lqs-savonet/README.md
+++ b/containers/lqs-savonet/README.md
@@ -1,0 +1,35 @@
+# Liquidsoap runtime image for the No Agenda 24/7 stream
+
+This directory builds the liquidsoap runtime image used by the No Agenda
+stream containers. The image contains only the liquidsoap runtime; the
+stream configuration (`noagenda.liq`, `include/`) is mounted into the
+container at runtime from the deployment host and is not baked into the
+image.
+
+## Base
+
+`docker.io/savonet/liquidsoap:v2.3.2` — the last liquidsoap release that ran
+without issues in production. Upstream has moved on; do not bump the base
+until the `next` branch has been validated on the test stream.
+
+## Build
+
+CI builds this image on every push to `stable` and `next` and publishes to
+GHCR:
+
+```text
+ghcr.io/noagenda/noagendastream:stable
+ghcr.io/noagenda/noagendastream:next
+```
+
+Local builds (e.g. for a container runtime without registry access):
+
+```sh
+podman build -t localhost/lqs-savonet:v2.3.2-250407T1327Z containers/lqs-savonet/
+```
+
+The uid/gid sync in the Containerfile (liquidsoap → 1002:100) matches the
+deployment host account (`rbemrose`, uid/gid 1002:100) so `UserNS=keep-id`
+in the Quadlets maps cleanly.
+
+Tag convention: `v<liquidsoap-version>-<build-timestamp UTC>`.


### PR DESCRIPTION
Adds the liquidsoap runtime image build sources to the public repo:

- `containers/lqs-savonet/Containerfile` (moved from noagendastream-deployment)
- `containers/lqs-savonet/README.md` (build + GHCR publishing notes)
- `.github/dependabot.yml` (Docker + GitHub Actions update tracking)

The publish workflow itself lands separately (PAT workflow scope).