### PR TITLE
Build on every push, publish only on stable and next

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,6 @@ name: Build and Publish Stream Image
 on:
   pull_request:
   push:
-    branches: [stable, next]
 
 permissions:
   contents: read
@@ -19,6 +18,18 @@ jobs:
         name: Checkout
         uses: actions/checkout@v4
       -
+        name: Determine publish target
+        id: publish
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == 'push' && \
+                ( "${{ github.ref }}" == 'refs/heads/stable' || \
+                  "${{ github.ref }}" == 'refs/heads/next' ) ]]; then
+            echo 'should-publish=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'should-publish=false' >> "$GITHUB_OUTPUT"
+          fi
+      -
         name: Set image tag
         id: image-tag
         shell: bash
@@ -33,7 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Login to GHCR
-        if: github.event_name == 'push'
+        if: steps.publish.outputs.should-publish == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -46,7 +57,7 @@ jobs:
         with:
           context: containers/lqs-savonet
           file: containers/lqs-savonet/Containerfile
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ steps.publish.outputs.should-publish == 'true' }}
           tags: |
             ghcr.io/noagenda/noagendastream:${{ steps.image-tag.outputs.branch }}
             ghcr.io/noagenda/noagendastream:${{ steps.image-tag.outputs.branch }}-${{ github.sha }}
@@ -55,7 +66,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
       -
         name: Print image digest
-        if: github.event_name == 'push'
+        if: steps.publish.outputs.should-publish == 'true'
         run: |
           echo "Published digest: ${{ steps.build.outputs.digest }}"
           echo "Full reference: ghcr.io/noagenda/noagendastream@${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
Matches the website repo's CI convention: the container is built after every push (all branches + PRs), but published to GHCR only on `stable` and `next`.