### PR TITLE
Point Dependabot updates at the next branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,14 @@ version: 2
 updates:
   - package-ecosystem: docker
     directory: /containers/lqs-savonet
+    target-branch: next
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: next
     schedule:
       interval: weekly
     open-pull-requests-limit: 3


### PR DESCRIPTION
Dependabot reads its config from the default branch (`stable`). Setting `target-branch: next` makes Dependabot open its PRs against `next` instead. The same change is already on `next` (57d6b59); this keeps the config on `stable` so Dependabot picks it up. Updates land on `next`, get validated on the test stream, and only later merge into `stable`.