### PR TITLE
Clarify CI build/publish behavior

### DIFF
--- a/containers/lqs-savonet/README.md
+++ b/containers/lqs-savonet/README.md
@@ -14,8 +14,8 @@ until the `next` branch has been validated on the test stream.
 
 ## Build
 
-CI builds this image on every push to `stable` and `next` and publishes to
-GHCR:
+CI builds this image on every push (all branches and pull requests) and
+publishes to GHCR only on `stable` and `next`:
 
 ```text
 ghcr.io/noagenda/noagendastream:stable


### PR DESCRIPTION
README-only update: CI builds on every push, publishes to GHCR only on `stable`/`next`.