### PR TITLE
chore(container): upgrade Liquidsoap to 2.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ This is community supported work. Let us know you appreciate the effort.
 Donations: http://dvorak.org/na
 
 All talk. No Commercials. No Agenda.
+
+## Runtime and branches
+
+The stream configuration runs on Liquidsoap 2.4.5. The runtime image is built
+from [`containers/lqs-savonet/`](containers/lqs-savonet/); the configuration
+and secrets are mounted at runtime and are not baked into the image.
+
+- `stable` contains the production configuration.
+- `next` contains changes being validated on the test stream before promotion
+  to production.
+
+## Metadata
+
+Automatic track metadata is normalized with `metadata.map`, which adds the
+public stream URL while preserving the title and other metadata fields.
+Listener-facing now-playing metadata can also be overridden manually through
+the custom Liquidsoap server command:
+
+```text
+metadata.update song==<now playing text>
+```
+
+That command uses `icy.update_metadata` for both Icecast outputs. A later track
+metadata event replaces the manual override in the normal way.
+
+Host-specific helper scripts and `include/secrets.liq` are intentionally not
+stored in this repository.

--- a/containers/lqs-savonet/Containerfile
+++ b/containers/lqs-savonet/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/savonet/liquidsoap:v2.3.2
+FROM docker.io/savonet/liquidsoap:v2.4.5
 
 ENTRYPOINT []
 

--- a/containers/lqs-savonet/README.md
+++ b/containers/lqs-savonet/README.md
@@ -8,9 +8,9 @@ image.
 
 ## Base
 
-`docker.io/savonet/liquidsoap:v2.3.2` — the last liquidsoap release that ran
-without issues in production. Upstream has moved on; do not bump the base
-until the `next` branch has been validated on the test stream.
+`docker.io/savonet/liquidsoap:v2.4.5` — validated with the `next` branch on
+the test stream, including playlist playback, Icecast outputs, metadata,
+harbor input, live-source transitions, and an extended runtime test.
 
 ## Build
 
@@ -25,7 +25,7 @@ ghcr.io/noagenda/noagendastream:next
 Local builds (e.g. for a container runtime without registry access):
 
 ```sh
-podman build -t localhost/lqs-savonet:v2.3.2-250407T1327Z containers/lqs-savonet/
+podman build -t localhost/lqs-savonet:v2.4.5-260801T0932Z containers/lqs-savonet/
 ```
 
 The uid/gid sync in the Containerfile (liquidsoap → 1002:100) matches the

--- a/include/radio.liq
+++ b/include/radio.liq
@@ -1,33 +1,35 @@
 # % -- include/radio.liq -- %
 # vim: ft=liq ts=4 sw=4 sts=2 et ai fdm=marker
 
+# Add the public stream URL while preserving each source's title and all
+# other metadata fields.
+def with_stream_metadata(m) =
+  [("title", m["title"]), ("comment", streamurl)]
+end
+
 # Sound effects
 elevator = mksafe(playlist(id="elevator", reload_mode="watch",
                     mode="normal",
                     basepath ^ "/jingles/elevator.m3u"))
-elevator = rewrite_metadata([("title","$(title)"),
-                             ("comment",streamurl)],elevator)
+elevator = metadata.map(with_stream_metadata, elevator)
 
 sweeper = mksafe(playlist(id="sweeper", reload_mode="watch",
                     mode="normal",
                     basepath ^ "/jingles/sweeper.m3u"))
-sweeper = rewrite_metadata([("title","$(title)"),
-                             ("comment",streamurl)],sweeper)
+sweeper = metadata.map(with_stream_metadata, sweeper)
 
 # List of shows
 nalist   = playlist(id="nalist", reload_mode="watch",
                     mode="normal",
                     prefetch=3,
                     basepath ^ "/mp3s/playlist.m3u")
-nalist   = rewrite_metadata([("title","$(title)"),
-                             ("comment",streamurl)],nalist)
+nalist   = metadata.map(with_stream_metadata, nalist)
 
 musiclist = playlist(id="musiclist", reload_mode="watch",
                     mode="normal",
                     prefetch=3,
                     basepath ^ "/mp3s/playlist-v4vmusic.m3u")
-musiclist = rewrite_metadata([("title","$(title)"),
-                             ("comment",streamurl)],musiclist)
+musiclist = metadata.map(with_stream_metadata, musiclist)
 
 # Input harbor
 def_buffer = 10. # seconds to buffer
@@ -45,13 +47,14 @@ darrenlive = input.harbor(id="darrenlive", "/",
                         icy=true)
 
 # Input harbor
-horolive = rewrite_metadata([("title", "LIVE: Dvorak and Horowitz Unplugged"),
-                             ("comment",streamurl)],
-                             input.harbor(id="horolive", "/",
-                             port=horo_inport,
-                             password=inpass,
-                             buffer=def_buffer,
-                             icy=true))
+horolive = metadata.map(
+  fun (_) -> [("title", "LIVE: Dvorak and Horowitz Unplugged"),
+              ("comment", streamurl)],
+  input.harbor(id="horolive", "/",
+               port=horo_inport,
+               password=inpass,
+               buffer=def_buffer,
+               icy=true))
 
 # Input harbor
 alsolive   = input.harbor(id="alsolive", "/",


### PR DESCRIPTION
## Summary
- upgrade the Savonet base image from Liquidsoap 2.3.2 to 2.4.5
- replace all deprecated `rewrite_metadata` calls with `metadata.map`
- preserve source titles, comments, and all unrelated metadata fields
- document the runtime image, branch policy, and manual metadata flow
- update the container build documentation

## Static validation
- `liquidsoap --check` passes with both 2.3.2 and 2.4.5
- no `rewrite_metadata` references or deprecation warnings remain
- Markdown contains no stale Liquidsoap 2.3.2 or `rewrite_metadata` references

## Staging validation
- both test Icecast mounts delivered MP3/44.1 kHz/stereo audio
- automatic playlist/sweeper metadata reached Icecast
- the staging copy of `bin/metadata` manually changed listener-facing now-playing metadata
- the staging copy of `bin/metadata_from_file` copied TIT2 metadata from an MP3 to listener-facing now-playing metadata
- normal source metadata replaced the manual override on the next source event
- telnet current metadata worked on port 2301
- harbor live-input and return-to-playlist transitions passed
- 2h12m Liquidsoap 2.4.5 runtime test completed without fatal errors, exceptions, crashes, or reconnects
- production remained untouched

## Operational note
The helper scripts call the custom `metadata.update` server command, which uses `icy.update_metadata` on the Icecast outputs. They do not call `rewrite_metadata` directly, and their behavior remains intact after this migration.
